### PR TITLE
Set the joint position with clamping

### DIFF
--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -144,7 +144,7 @@ where
     /// // Initial position is 0.0
     /// assert_eq!(rot.joint_position().unwrap(), 0.0);
     /// rot.set_joint_position_clamped(2.0);
-    // assert_eq!(rot.joint_position().unwrap(), 1.0);
+    /// assert_eq!(rot.joint_position().unwrap(), 1.0);
     /// rot.set_joint_position_clamped(-2.0);
     /// assert_eq!(rot.joint_position().unwrap(), -1.0);
     /// ```

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -152,7 +152,8 @@ where
     pub fn set_joint_position_clamped(&mut self, position: T) {
         if !self.is_movable() {
             return;
-        } else if let Some(ref range) = self.limits {
+        }
+        if let Some(ref range) = self.limits {
             let position_clamped = range.clamp(position);
             self.position = position_clamped;
         } else {

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -153,15 +153,12 @@ where
         if !self.is_movable() {
             return;
         }
-        if let Some(ref range) = self.limits {
-            let position_clamped = range.clamp(position);
-            self.position = position_clamped;
+        let position_clamped = if let Some(ref range) = self.limits {
+            range.clamp(position)
         } else {
-            self.position = position;
-        }
-        // TODO: have to reset descendent `world_transform_cache`
-        self.world_transform_cache.replace(None);
-        self.world_velocity_cache.replace(None);
+            position
+        };
+        self.set_joint_position_unchecked(position_clamped);
     }
     pub fn set_joint_position_unchecked(&mut self, position: T) {
         self.position = position;

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -125,6 +125,43 @@ where
         self.world_velocity_cache.replace(None);
         Ok(())
     }
+    /// Set the clamped position of the joint
+    ///
+    /// It refers to the joint limit and clamps the argument. This function does nothing if this is fixed joint.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate nalgebra as na;
+    /// extern crate k;
+    ///
+    /// // Create rotational joint with Y-axis
+    /// let mut rot = k::Joint::<f64>::new("r0", k::JointType::Rotational { axis: na::Vector3::y_axis() });
+    ///
+    /// let limits = k::joint::Range::new(-1.0, 1.0);
+    /// rot.limits = Some(limits);
+    ///
+    /// // Initial position is 0.0
+    /// assert_eq!(rot.joint_position().unwrap(), 0.0);
+    /// rot.set_joint_position_clamped(2.0);
+    // assert_eq!(rot.joint_position().unwrap(), 1.0);
+    /// rot.set_joint_position_clamped(-2.0);
+    /// assert_eq!(rot.joint_position().unwrap(), -1.0);
+    /// ```
+    ///
+    pub fn set_joint_position_clamped(&mut self, position: T) {
+        if let JointType::Fixed = self.joint_type {
+            return;
+        } else if let Some(ref range) = self.limits {
+            let position_clamped = range.clamp(position);
+            self.position = position_clamped;
+        } else {
+            self.position = position;
+        }
+        // TODO: have to reset descendent `world_transform_cache`
+        self.world_transform_cache.replace(None);
+        self.world_velocity_cache.replace(None);
+    }
     pub fn set_joint_position_unchecked(&mut self, position: T) {
         self.position = position;
         // TODO: have to reset descendent `world_transform_cache`

--- a/src/joint/joint.rs
+++ b/src/joint/joint.rs
@@ -104,7 +104,7 @@ where
     /// ```
     ///
     pub fn set_joint_position(&mut self, position: T) -> Result<(), Error> {
-        if let JointType::Fixed = self.joint_type {
+        if !self.is_movable() {
             return Err(Error::SetToFixedError {
                 joint_name: self.name.to_string(),
             });
@@ -150,7 +150,7 @@ where
     /// ```
     ///
     pub fn set_joint_position_clamped(&mut self, position: T) {
-        if let JointType::Fixed = self.joint_type {
+        if !self.is_movable() {
             return;
         } else if let Some(ref range) = self.limits {
             let position_clamped = range.clamp(position);

--- a/src/joint/range.rs
+++ b/src/joint/range.rs
@@ -56,6 +56,25 @@ where
     pub fn is_valid(&self, val: T) -> bool {
         val <= self.max && val >= self.min
     }
+    /// Clamp the value with the range
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let range = k::joint::Range::new(-1.0, 1.0);
+    /// assert_eq!(range.clamp(0.5), 0.5);
+    /// assert_eq!(range.clamp(2.0), 1.0);
+    /// assert_eq!(range.clamp(-2.0), -1.0);
+    /// ```
+    pub fn clamp(&self, val: T) -> T {
+        if val < self.min {
+            self.min
+        } else if val > self.max {
+            self.max
+        } else {
+            val
+        }
+    }
 }
 
 impl<T> From<::std::ops::RangeInclusive<T>> for Range<T>


### PR DESCRIPTION
This PR adds a new function to set the joint position.
In the procedure of assignment, the function clamps the joint position if it is out of joint limits, so that the joint position is always in the joint limit.